### PR TITLE
Additional options to config __init__, including genbank compatibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ argparse==1.2.1
 biopython==1.62b
 nose==1.3.0
 numpy==1.7.1
-optmage==0.9
 wsgiref==0.1.2

--- a/src/optmage/oligo_designer.py
+++ b/src/optmage/oligo_designer.py
@@ -487,7 +487,7 @@ class OligoGenerator(object):
         until a window is found that satisfies the secondary structure free
         energy constraint.
         """
-        initial_midpoint = len(block_seq) / 2
+        initial_midpoint = int(len(block_seq) / 2)
         current_midpoint = initial_midpoint
         wiggle = 1
         mut_len = len(oligo_target.mutation_seq)


### PR DESCRIPTION
1. Choose genome type (genbank/fasta)
2. option to constrain first base of oligo to a specific nucleotide
3. explicitly include upstream and downstream homology regions in output
4. fixed error for large oligos, where block length was too short in some cases to fit homology arms.